### PR TITLE
Added TTS to events

### DIFF
--- a/FFXIVAPP.Plugin.Event/FFXIVAPP.Plugin.Event.csproj
+++ b/FFXIVAPP.Plugin.Event/FFXIVAPP.Plugin.Event.csproj
@@ -48,7 +48,7 @@
     </Reference>
     <Reference Include="HtmlAgilityPack, Version=1.4.9.0, Culture=neutral, PublicKeyToken=bd319b19eaf3b43a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\ffxivapp-aio\packages\HtmlAgilityPack.1.4.9\lib\Net45\HtmlAgilityPack.dll</HintPath>
+      <HintPath>..\..\ffxivapp-resources\HtmlAgilityPack.dll</HintPath>
     </Reference>
     <Reference Include="MahApps.Metro">
       <HintPath>..\..\ffxivapp-resources\MahApps.Metro.dll</HintPath>
@@ -64,7 +64,7 @@
     </Reference>
     <Reference Include="NLog, Version=3.1.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\ffxivapp-aio\packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\ffxivapp-resources\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/FFXIVAPP.Plugin.Event/FFXIVAPP.Plugin.Event.csproj
+++ b/FFXIVAPP.Plugin.Event/FFXIVAPP.Plugin.Event.csproj
@@ -73,6 +73,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Speech" />
     <Reference Include="System.Windows.Interactivity, Version=4.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\ffxivapp-resources\System.Windows.Interactivity.dll</HintPath>

--- a/FFXIVAPP.Plugin.Event/FFXIVAPP.Plugin.Event.csproj
+++ b/FFXIVAPP.Plugin.Event/FFXIVAPP.Plugin.Event.csproj
@@ -100,6 +100,7 @@
     <Compile Include="ShellViewModel.cs" />
     <Compile Include="Utilities\ExecutableHelper.cs" />
     <Compile Include="Utilities\LogPublisher.cs" />
+    <Compile Include="Utilities\TTSPlayer.cs" />
     <Compile Include="ViewModels\SettingsViewModel.cs">
       <SubType>
       </SubType>

--- a/FFXIVAPP.Plugin.Event/Initializer.cs
+++ b/FFXIVAPP.Plugin.Event/Initializer.cs
@@ -144,6 +144,7 @@ namespace FFXIVAPP.Plugin.Event
                     var xValue = xElement.GetElementValue("Value", string.Empty);
                     var xSound = xElement.GetElementValue("Sound", string.Empty);
                     var xTTS = xElement.GetElementValue("TTS", string.Empty);
+                    var xRate = xElement.GetElementValue("Rate", -2);
                     var xVolume = xElement.GetElementValue("Volume", 1.0d);
                     var xDelay = xElement.GetElementValue("Delay", 0);
                     var xCategory = xElement.GetElementValue("Category", defaultCategory);
@@ -157,6 +158,7 @@ namespace FFXIVAPP.Plugin.Event
                         Key = xKey,
                         Sound = xSound,
                         TTS = xTTS,
+                        Rate = xRate,
                         Delay = xDelay,
                         Volume = xVolume,
                         RegEx = xRegEx,

--- a/FFXIVAPP.Plugin.Event/Initializer.cs
+++ b/FFXIVAPP.Plugin.Event/Initializer.cs
@@ -143,6 +143,7 @@ namespace FFXIVAPP.Plugin.Event
 
                     var xValue = xElement.GetElementValue("Value", string.Empty);
                     var xSound = xElement.GetElementValue("Sound", string.Empty);
+                    var xTTS = xElement.GetElementValue("TTS", string.Empty);
                     var xVolume = xElement.GetElementValue("Volume", 1.0d);
                     var xDelay = xElement.GetElementValue("Delay", 0);
                     var xCategory = xElement.GetElementValue("Category", defaultCategory);
@@ -155,6 +156,7 @@ namespace FFXIVAPP.Plugin.Event
                     {
                         Key = xKey,
                         Sound = xSound,
+                        TTS = xTTS,
                         Delay = xDelay,
                         Volume = xVolume,
                         RegEx = xRegEx,

--- a/FFXIVAPP.Plugin.Event/Models/LogEvent.cs
+++ b/FFXIVAPP.Plugin.Event/Models/LogEvent.cs
@@ -42,6 +42,7 @@ namespace FFXIVAPP.Plugin.Event.Models
             Executable = "";
             Sound = "";
             Volume = 100;
+            TTS = "";
         }
 
         #region Property Bindings
@@ -55,6 +56,7 @@ namespace FFXIVAPP.Plugin.Event.Models
         private string _regEx;
         private string _sound;
         private double _volume;
+        private string _tts;
 
         public Guid Key
         {
@@ -72,6 +74,16 @@ namespace FFXIVAPP.Plugin.Event.Models
             set
             {
                 _sound = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public string TTS
+        {
+            get { return _tts; }
+            set
+            {
+                _tts = value;
                 RaisePropertyChanged();
             }
         }

--- a/FFXIVAPP.Plugin.Event/Models/LogEvent.cs
+++ b/FFXIVAPP.Plugin.Event/Models/LogEvent.cs
@@ -43,6 +43,7 @@ namespace FFXIVAPP.Plugin.Event.Models
             Sound = "";
             Volume = 100;
             TTS = "";
+            Rate = -2;
         }
 
         #region Property Bindings
@@ -57,6 +58,7 @@ namespace FFXIVAPP.Plugin.Event.Models
         private string _sound;
         private double _volume;
         private string _tts;
+        private int _rate;
 
         public Guid Key
         {
@@ -84,6 +86,16 @@ namespace FFXIVAPP.Plugin.Event.Models
             set
             {
                 _tts = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        public int Rate
+        {
+            get { return _rate; }
+            set
+            {
+                _rate = value;
                 RaisePropertyChanged();
             }
         }

--- a/FFXIVAPP.Plugin.Event/Properties/Settings.cs
+++ b/FFXIVAPP.Plugin.Event/Properties/Settings.cs
@@ -266,6 +266,7 @@ namespace FFXIVAPP.Plugin.Event.Properties
                 var xKey = (item.Key != Guid.Empty ? item.Key : Guid.NewGuid()).ToString();
                 var xRegEx = item.RegEx;
                 var xSound = item.Sound;
+                var xTTS = item.TTS;
                 var xVolume = item.Volume;
                 var xDelay = item.Delay;
                 var xCategory = item.Category;
@@ -283,6 +284,11 @@ namespace FFXIVAPP.Plugin.Event.Properties
                     {
                         Key = "Sound",
                         Value = xSound
+                    },
+                    new XValuePair
+                    {
+                        Key = "TTS",
+                        Value = xTTS,
                     },
                     new XValuePair
                     {

--- a/FFXIVAPP.Plugin.Event/Properties/Settings.cs
+++ b/FFXIVAPP.Plugin.Event/Properties/Settings.cs
@@ -267,6 +267,7 @@ namespace FFXIVAPP.Plugin.Event.Properties
                 var xRegEx = item.RegEx;
                 var xSound = item.Sound;
                 var xTTS = item.TTS;
+                var xRate = item.Rate;
                 var xVolume = item.Volume;
                 var xDelay = item.Delay;
                 var xCategory = item.Category;
@@ -289,6 +290,11 @@ namespace FFXIVAPP.Plugin.Event.Properties
                     {
                         Key = "TTS",
                         Value = xTTS,
+                    },
+                    new XValuePair
+                    {
+                        Key = "Rate",
+                        Value = xRate.ToString(CultureInfo.InvariantCulture),
                     },
                     new XValuePair
                     {

--- a/FFXIVAPP.Plugin.Event/Utilities/LogPublisher.cs
+++ b/FFXIVAPP.Plugin.Event/Utilities/LogPublisher.cs
@@ -60,6 +60,7 @@ namespace FFXIVAPP.Plugin.Event.Utilities
                 {
                     var resuccess = false;
                     var arguments = item.Arguments;
+                    var tts = item.TTS;
                     if (SharedRegEx.IsValidRegex(item.RegEx))
                     {
                         var reg = Regex.Match(line, item.RegEx);
@@ -67,6 +68,7 @@ namespace FFXIVAPP.Plugin.Event.Utilities
                         {
                             resuccess = true;
                             arguments = reg.Result(item.Arguments);
+                            tts = reg.Result(tts);
                         }
                     }
                     else
@@ -78,7 +80,7 @@ namespace FFXIVAPP.Plugin.Event.Utilities
                         continue;
                     }
 
-                    ExecutLogEvent(item, arguments);
+                    ExecutLogEvent(item, arguments, tts);
                 }
             }
             catch (Exception ex)
@@ -87,7 +89,7 @@ namespace FFXIVAPP.Plugin.Event.Utilities
             }
         }
 
-        private static void ExecutLogEvent(LogEvent logEvent, string arguments)
+        private static void ExecutLogEvent(LogEvent logEvent, string arguments, string tts)
         {
             var volume = Convert.ToInt32(logEvent.Volume * Settings.Default.GlobalVolume);
 
@@ -95,7 +97,7 @@ namespace FFXIVAPP.Plugin.Event.Utilities
                           {
                               PlaySound(logEvent, volume),
                               RunExecutable(logEvent, arguments),
-                              PlayTTS(logEvent, volume)
+                              PlayTTS(tts, volume)
                           };
             actions.RemoveAll(a => a == null);
             if (!actions.Any())
@@ -145,15 +147,14 @@ namespace FFXIVAPP.Plugin.Event.Utilities
             return () => ExecutableHelper.Run(logEvent.Executable, arguments);
         }
 
-        private static Action PlayTTS(LogEvent logEvent, int volume)
+        private static Action PlayTTS(string tts, int volume)
         {
-            var tts = logEvent.TTS;
             if (String.IsNullOrWhiteSpace(tts))
             {
                 return null;
             }
 
-            return () => new TTSPlayer().Speak(tts, volume);
+            return () => TTSPlayer.Speak(tts, volume);
         }
 
         private static void ExecuteActions(IEnumerable<Action> actions)

--- a/FFXIVAPP.Plugin.Event/Utilities/LogPublisher.cs
+++ b/FFXIVAPP.Plugin.Event/Utilities/LogPublisher.cs
@@ -95,7 +95,7 @@ namespace FFXIVAPP.Plugin.Event.Utilities
             }
             else
             {
-                var timer = new Timer(delay > 0 ? delay * 1000 : 1);
+                var timer = new Timer(delay * 1000);
                 ElapsedEventHandler timerEventHandler = null;
                 timerEventHandler = delegate
                 {

--- a/FFXIVAPP.Plugin.Event/Utilities/LogPublisher.cs
+++ b/FFXIVAPP.Plugin.Event/Utilities/LogPublisher.cs
@@ -97,7 +97,7 @@ namespace FFXIVAPP.Plugin.Event.Utilities
                           {
                               PlaySound(logEvent, volume),
                               RunExecutable(logEvent, arguments),
-                              PlayTTS(tts, volume)
+                              PlayTTS(tts, volume, logEvent.Rate),
                           };
             actions.RemoveAll(a => a == null);
             if (!actions.Any())
@@ -147,14 +147,14 @@ namespace FFXIVAPP.Plugin.Event.Utilities
             return () => ExecutableHelper.Run(logEvent.Executable, arguments);
         }
 
-        private static Action PlayTTS(string tts, int volume)
+        private static Action PlayTTS(string tts, int volume, int rate)
         {
             if (String.IsNullOrWhiteSpace(tts))
             {
                 return null;
             }
 
-            return () => TTSPlayer.Speak(tts, volume);
+            return () => TTSPlayer.Speak(tts, volume, rate);
         }
 
         private static void ExecuteActions(IEnumerable<Action> actions)

--- a/FFXIVAPP.Plugin.Event/Utilities/TTSPlayer.cs
+++ b/FFXIVAPP.Plugin.Event/Utilities/TTSPlayer.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Speech.AudioFormat;
+using System.Speech.Synthesis;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Automation.Peers;
+using FFXIVAPP.Common.Audio;
+using NAudio.Wave;
+
+namespace FFXIVAPP.Plugin.Event.Utilities
+{
+    public class TTSPlayer
+    {
+        private const int Latency = 100;
+        private static readonly ConcurrentDictionary<Tuple<string, int>, byte[]> Cached;
+
+        static TTSPlayer()
+        {
+            Cached = new ConcurrentDictionary<Tuple<string, int>, byte[]>(new KeyEqualityComparer());
+        }
+
+        private DirectSoundOut _directSoundOut;
+        private WaveFileReader _waveFileReader;
+        private WaveChannel32 _waveChannel;
+        private MemoryStream _memoryStream;
+
+        public TTSPlayer()
+        {
+        }
+
+        public void Speak(string tts, int volume)
+        {
+            _memoryStream = GetMemoryStream(tts, volume);
+            _directSoundOut = (Common.Constants.DefaultAudioDevice == Guid.Empty)
+                ? new DirectSoundOut(Latency)
+                : new DirectSoundOut(Common.Constants.DefaultAudioDevice, Latency);
+            _waveFileReader = new WaveFileReader(_memoryStream);
+            _waveChannel = new WaveChannel32(_waveFileReader);
+            _directSoundOut.Init(_waveChannel);
+            _directSoundOut.Play();
+            _directSoundOut.PlaybackStopped += DisposeDirectSound;
+        }
+
+        private static MemoryStream GetMemoryStream(string tts, int volume)
+        {
+            var tuple = new Tuple<string, int>(tts, volume);
+            var ttsData = Cached.GetOrAdd(tuple,
+                _ =>
+                {
+                    using (var memstream = new MemoryStream())
+                    {
+                        using (var synthesizer = new SpeechSynthesizer())
+                        {
+                            synthesizer.SetOutputToWaveStream(memstream);
+                            synthesizer.Volume = volume;
+                            synthesizer.Rate = -2;
+
+                            synthesizer.Speak(tts);
+                        }
+                        memstream.Seek(0, SeekOrigin.Begin);
+                        return memstream.ToArray();
+                    }
+                });
+            return new MemoryStream(ttsData);
+        }
+
+        private void DisposeDirectSound(object sender, StoppedEventArgs e)
+        {
+            _directSoundOut.PlaybackStopped -= DisposeDirectSound;
+            Dispose();
+        }
+
+        private void Dispose()
+        {
+            if (_waveChannel != null)
+                _waveChannel.Dispose();
+            _waveChannel = null;
+
+            if (_waveFileReader != null)
+                _waveFileReader.Dispose();
+            _waveFileReader = null;
+
+            if (_directSoundOut != null)
+                _directSoundOut.Dispose();
+            _directSoundOut = null;
+        }
+
+        private class KeyEqualityComparer : IEqualityComparer<Tuple<string, int>>
+        {
+            public bool Equals(Tuple<string, int> x, Tuple<string, int> y)
+            {
+                return x.Item2 == y.Item2
+                       && string.Equals(x.Item1, y.Item1, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public int GetHashCode(Tuple<string, int> obj)
+            {
+                return obj.GetHashCode();
+            }
+        }
+    }
+}

--- a/FFXIVAPP.Plugin.Event/ViewModels/MainViewModel.cs
+++ b/FFXIVAPP.Plugin.Event/ViewModels/MainViewModel.cs
@@ -137,7 +137,7 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
             }
             if (!string.IsNullOrWhiteSpace(MainView.View.TTTS.Text))
             {
-                TTSPlayer.Speak(MainView.View.TTTS.Text, volume);
+                TTSPlayer.Speak(MainView.View.TTTS.Text, volume, (int)MainView.View.TRate.Value);
             }
         }
 
@@ -180,6 +180,7 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
             {
                 Sound = MainView.View.TSound.Text,
                 TTS = (MainView.View.TTTS.Text ?? "").Trim(),
+                Rate = (int)MainView.View.TRate.Value,
                 RegEx = MainView.View.TRegEx.Text,
                 Category = MainView.View.TCategory.Text,
                 Executable = MainView.View.TExecutable.Text,
@@ -257,6 +258,7 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
             MainView.View.TSound.Text = GetValueBySelectedItem(MainView.View.Events, "Sound");
             MainView.View.TTTS.Text = GetValueBySelectedItem(MainView.View.Events, "TTS");
             MainView.View.TVolume.Value = Convert.ToDouble(GetValueBySelectedItem(MainView.View.Events, "Volume")) / 100;
+            MainView.View.TRate.Value = Convert.ToDouble(GetValueBySelectedItem(MainView.View.Events, "Rate"));
             MainView.View.TDelay.Text = GetValueBySelectedItem(MainView.View.Events, "Delay");
             MainView.View.TRegEx.Text = GetValueBySelectedItem(MainView.View.Events, "RegEx");
             MainView.View.TCategory.Text = GetValueBySelectedItem(MainView.View.Events, "Category");

--- a/FFXIVAPP.Plugin.Event/ViewModels/MainViewModel.cs
+++ b/FFXIVAPP.Plugin.Event/ViewModels/MainViewModel.cs
@@ -43,6 +43,7 @@ using FFXIVAPP.Common.Utilities;
 using FFXIVAPP.Common.ViewModelBase;
 using FFXIVAPP.Plugin.Event.Models;
 using FFXIVAPP.Plugin.Event.Properties;
+using FFXIVAPP.Plugin.Event.Utilities;
 using FFXIVAPP.Plugin.Event.Views;
 using Microsoft.Win32;
 using NLog;
@@ -129,12 +130,15 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
 
         private static void TestSound()
         {
-            if (MainView.View.TSound.Text.Trim() == "")
+            var volume = Convert.ToInt32((MainView.View.TVolume.Value*100)*Settings.Default.GlobalVolume);
+            if (!string.IsNullOrWhiteSpace(MainView.View.TSound.Text))
             {
-                return;
+                SoundPlayerHelper.PlayCached(MainView.View.TSound.Text, volume);
             }
-            var volume = (MainView.View.TVolume.Value * 100) * Settings.Default.GlobalVolume;
-            SoundPlayerHelper.PlayCached(MainView.View.TSound.Text, (int) volume);
+            if (!string.IsNullOrWhiteSpace(MainView.View.TTTS.Text))
+            {
+                new TTSPlayer().Speak(MainView.View.TTTS.Text, volume);
+            }
         }
 
         /// <summary>
@@ -175,6 +179,7 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
             var logEvent = new LogEvent
             {
                 Sound = MainView.View.TSound.Text,
+                TTS = (MainView.View.TTTS.Text ?? "").Trim(),
                 RegEx = MainView.View.TRegEx.Text,
                 Category = MainView.View.TCategory.Text,
                 Executable = MainView.View.TExecutable.Text,
@@ -200,6 +205,7 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
             }
             MainView.View.Events.UnselectAll();
             MainView.View.TRegEx.Text = "";
+            MainView.View.TTTS.Text = "";
             MainView.View.TExecutable.Text = "";
             MainView.View.TArguments.Text = "";
         }
@@ -249,6 +255,7 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
                 return;
             }
             MainView.View.TSound.Text = GetValueBySelectedItem(MainView.View.Events, "Sound");
+            MainView.View.TTTS.Text = GetValueBySelectedItem(MainView.View.Events, "TTS");
             MainView.View.TVolume.Value = Convert.ToDouble(GetValueBySelectedItem(MainView.View.Events, "Volume")) / 100;
             MainView.View.TDelay.Text = GetValueBySelectedItem(MainView.View.Events, "Delay");
             MainView.View.TRegEx.Text = GetValueBySelectedItem(MainView.View.Events, "RegEx");

--- a/FFXIVAPP.Plugin.Event/ViewModels/MainViewModel.cs
+++ b/FFXIVAPP.Plugin.Event/ViewModels/MainViewModel.cs
@@ -137,7 +137,7 @@ namespace FFXIVAPP.Plugin.Event.ViewModels
             }
             if (!string.IsNullOrWhiteSpace(MainView.View.TTTS.Text))
             {
-                new TTSPlayer().Speak(MainView.View.TTTS.Text, volume);
+                TTSPlayer.Speak(MainView.View.TTTS.Text, volume);
             }
         }
 

--- a/FFXIVAPP.Plugin.Event/Views/MainView.xaml
+++ b/FFXIVAPP.Plugin.Event/Views/MainView.xaml
@@ -155,32 +155,61 @@
                                       Height="27"
                                       IsReadOnly="False" />
                         </Grid>
-                        <DockPanel Height="30" Margin="3 0 0 0">
-                            <TextBlock Padding="5"
-                                       Text="{Binding Locale[event_VolumeLabel],
-                                                      Source={StaticResource PluginViewModel}}" />
-                            <TextBlock Width="60"
-                                       VerticalAlignment="Center"
-                                       Margin="3 0 0 0"
-                                       Height="27"
-                                       Padding="5"
-                                       Text="{Binding ElementName=TVolume,
-                                                      Path=Value,
-                                                      StringFormat=\{0:P2\}}" />
-                            <Button Margin="3 0 0 0"
-                                    Height="27"
-                                    Command="{Binding TestSoundCommand}"
-                                    Content="{Binding Locale[event_TestSoundButtonText],
-                                                      Source={StaticResource PluginViewModel}}"
-                                    DockPanel.Dock="Right" />
-                            <Slider x:Name="TVolume"
-                                    IsSnapToTickEnabled="True"
-                                    Maximum="1"
-                                    Minimum="0"
-                                    TickFrequency="0.025"
-                                    TickPlacement="BottomRight"
-                                    Value="1" />
-                        </DockPanel>
+                        <Grid Margin="3">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="33" />
+                                <RowDefinition Height="33" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <DockPanel Height="30" Margin="3 0 0 0" Grid.Column="0" Grid.Row="0">
+                                <TextBlock Padding="5"
+                                           Text="{Binding Locale[event_VolumeLabel],
+                                                          Source={StaticResource PluginViewModel}}" />
+                                <TextBlock Width="60"
+                                           VerticalAlignment="Center"
+                                           Margin="3 0 0 0"
+                                           Height="27"
+                                           Padding="5"
+                                           Text="{Binding ElementName=TVolume,
+                                                          Path=Value,
+                                                          StringFormat=\{0:P2\}}" />
+                                <Button Margin="3 0 0 0"
+                                        Height="27"
+                                        Command="{Binding TestSoundCommand}"
+                                        Content="{Binding Locale[event_TestSoundButtonText],
+                                                          Source={StaticResource PluginViewModel}}"
+                                        DockPanel.Dock="Right" />
+                                <Slider x:Name="TVolume"
+                                        IsSnapToTickEnabled="True"
+                                        Maximum="1"
+                                        Minimum="0"
+                                        TickFrequency="0.025"
+                                        TickPlacement="BottomRight"
+                                        Value="1" />
+                            </DockPanel>
+                            <DockPanel Height="30" Margin="3 0 0 0" Grid.Column="0" Grid.Row="1">
+                                <TextBlock Padding="5"
+                                           Text="Rate" />
+                                <TextBlock Width="60"
+                                           VerticalAlignment="Center"
+                                           Margin="3 0 0 0"
+                                           Height="27"
+                                           Padding="5"
+                                           Text="{Binding ElementName=TRate,
+                                                          Path=Value,
+                                                          StringFormat=\{0:N\}}" />
+                                <Slider x:Name="TRate"
+                                        IsSnapToTickEnabled="True"
+                                        Maximum="10"
+                                        Minimum="-10"
+                                        TickFrequency="1"
+                                        TickPlacement="BottomRight"
+                                        Value="-2" />
+                            </DockPanel>
+
+                        </Grid>
                     </DockPanel>
                 </Expander>
                 <Expander Header="{Binding Locale[event_ExecutableOptionsHeader],

--- a/FFXIVAPP.Plugin.Event/Views/MainView.xaml
+++ b/FFXIVAPP.Plugin.Event/Views/MainView.xaml
@@ -126,35 +126,61 @@
                                            Source={StaticResource PluginViewModel}}">
                     <DockPanel Margin="3"
                                LastChildFill="True">
-                        <TextBlock Padding="5"
-                                   Text="{Binding Locale[event_SoundLabel],
-                                                  Source={StaticResource PluginViewModel}}" />
-                        <ComboBox x:Name="TSound"
-                                  Width="120"
-                                  IsReadOnly="False"
-                                  ItemsSource="{Binding SoundFiles,
-                                                        Source={StaticResource PluginViewModel}}" />
-                        <TextBlock Padding="5"
-                                   Text="{Binding Locale[event_VolumeLabel],
-                                                  Source={StaticResource PluginViewModel}}" />
-                        <TextBlock Width="60"
-                                   VerticalAlignment="Center"
-                                   Padding="5"
-                                   Text="{Binding ElementName=TVolume,
-                                                  Path=Value,
-                                                  StringFormat=\{0:P2\}}" />
-                        <Button Margin="3 0 0 0"
-                                Command="{Binding TestSoundCommand}"
-                                Content="{Binding Locale[event_TestSoundButtonText],
-                                                  Source={StaticResource PluginViewModel}}"
-                                DockPanel.Dock="Right" />
-                        <Slider x:Name="TVolume"
-                                IsSnapToTickEnabled="True"
-                                Maximum="1"
-                                Minimum="0"
-                                TickFrequency="0.025"
-                                TickPlacement="BottomRight"
-                                Value="1" />
+                        <Grid Margin="3">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="33" />
+                                <RowDefinition Height="33" />
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="250"/>
+                            </Grid.ColumnDefinitions>
+                            <TextBlock Grid.Column="0" Grid.Row="0"
+                                       Padding="5"
+                                       Text="{Binding Locale[event_SoundLabel],
+                                                      Source={StaticResource PluginViewModel}}" />
+                            <ComboBox Grid.Column="1" Grid.Row="0"
+                                      x:Name="TSound"
+                                      Width="Auto"
+                                      Height="27"
+                                      IsReadOnly="False"
+                                      ItemsSource="{Binding SoundFiles,
+                                                            Source={StaticResource PluginViewModel}}" />
+                            <TextBlock Grid.Column="0" Grid.Row="1"
+                                       Padding="5"
+                                       Text="TTS" />
+                            <TextBox Grid.Column="1" Grid.Row="1"
+                                      x:Name="TTTS"
+                                      Width="Auto"
+                                      Height="27"
+                                      IsReadOnly="False" />
+                        </Grid>
+                        <DockPanel Height="30" Margin="3 0 0 0">
+                            <TextBlock Padding="5"
+                                       Text="{Binding Locale[event_VolumeLabel],
+                                                      Source={StaticResource PluginViewModel}}" />
+                            <TextBlock Width="60"
+                                       VerticalAlignment="Center"
+                                       Margin="3 0 0 0"
+                                       Height="27"
+                                       Padding="5"
+                                       Text="{Binding ElementName=TVolume,
+                                                      Path=Value,
+                                                      StringFormat=\{0:P2\}}" />
+                            <Button Margin="3 0 0 0"
+                                    Height="27"
+                                    Command="{Binding TestSoundCommand}"
+                                    Content="{Binding Locale[event_TestSoundButtonText],
+                                                      Source={StaticResource PluginViewModel}}"
+                                    DockPanel.Dock="Right" />
+                            <Slider x:Name="TVolume"
+                                    IsSnapToTickEnabled="True"
+                                    Maximum="1"
+                                    Minimum="0"
+                                    TickFrequency="0.025"
+                                    TickPlacement="BottomRight"
+                                    Value="1" />
+                        </DockPanel>
                     </DockPanel>
                 </Expander>
                 <Expander Header="{Binding Locale[event_ExecutableOptionsHeader],


### PR DESCRIPTION
The TTS follows the standard rules for regex match/replace, so you could do something like this:
Text: ^Your spiritbond with the (.*) is complete!
TTS: $1
Output to speakers: Electrum Ring (or whatever the item was)

The TTS engine uses whatever is default in Windows, if someone doesn't like the sound then different TTS engines can be installed.  I don't know of any offhand.

I modified the path of the DDLs in ffxivapp-aio to ffxivapp-resources so all DLLs were referenced in the same way.